### PR TITLE
Syntax - Allow space before `ok` or `not ok`

### DIFF
--- a/syntaxes/tap.tmLanguage.json
+++ b/syntaxes/tap.tmLanguage.json
@@ -18,7 +18,7 @@
         "match": "^\\d+\\.\\.\\d+$",
         "name": "storage.modifier"
     }, {
-        "match": "^((ok|not ok) \\d+)( - ([^#\\n]*))?",
+        "match": "^\\s*((ok|not ok) \\d+)( - ([^#\\n]*))?",
         "captures": {
             "1": {"name": "storage.type"},
             "4": {"name": "string.unquoted"}


### PR DESCRIPTION
It is now possible to use nested test plan.