### PR TITLE
Package - Change gallery baner theme to light

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "icon": "images/icon.png",
     "galleryBanner": {
         "color": "#FFFFFF",
-        "theme": "dark"
+        "theme": "light"
     },
     "activationEvents": [
         "onLanguage:tap"


### PR DESCRIPTION
Changing the banner theme to light (a.k.a the banner font to dark) allow to keep a white background according to the [TAP website](https://testanything.org/).

This fix #14 